### PR TITLE
error validation with swiss french languageCode (issue #68)

### DIFF
--- a/input/examples/bundle/1-2-MedicationDispense.xml
+++ b/input/examples/bundle/1-2-MedicationDispense.xml
@@ -17,7 +17,7 @@
         <resource>
             <Composition>
                 <id value="1-2-MedicationDispense"/>
-                <language value="de-CH"/>
+                <language value="fr-CH"/>
                 <extension url="http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-epr-informationrecipient">
                     <valueReference>
                         <reference value="Patient/MonikaWegmuellerRecipient"/>


### PR DESCRIPTION
If the languageCode of a MedicationDispense Composition (and probably others) is changed from de-CH to fr-CH (or it-CH), an error is raised:

Bundle.entry:Composition: minimum required = 1, but only found 0 (from http://fhir.ch/ig/ch-emed/StructureDefinition/ch-emed-document-medicationdispense)

